### PR TITLE
Add CI build workflow for Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.x'
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
+      - name: Build
+        run: |
+          go build ./...


### PR DESCRIPTION
## Summary
- build project on Ubuntu using GitHub Actions
- install libcurl before building

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_686df42b10b48325a32e2aa66129efd0