### PR TITLE
Add Windows build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,23 @@ jobs:
       - name: Build
         run: |
           go build ./...
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-curl
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '^1.24'
+      - name: Build
+        shell: msys2 {0}
+        run: |
+          export CC=x86_64-w64-mingw32-gcc
+          export CGO_ENABLED=1
+          go build ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '^1.24'
+      - name: Export GOROOT
+        shell: bash
+        run: echo "GOROOT=$(go env GOROOT)" >> "$GITHUB_ENV"
       - name: Build
         shell: msys2 {0}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Build
         shell: msys2 {0}
         run: |
+          export PATH="$(cygpath -u "$GOROOT")/bin:$PATH"
           export CC=x86_64-w64-mingw32-gcc
           export CGO_ENABLED=1
           go build ./...

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ I started with a few libraries based on what I had seen other people use (`-lcur
 
 The repository includes an example workflow that builds on Windows using
 [msys2/setup-msys2](https://github.com/msys2/setup-msys2). The workflow installs
-`mingw-w64-x86_64-gcc` and `mingw-w64-x86_64-curl` via `pacman` and then runs the
-build inside the msys2 environment. You can see the exact steps in
-`.github/workflows/build.yml`.
+`mingw-w64-x86_64-gcc` and `mingw-w64-x86_64-curl` via `pacman`. It then runs the
+build inside the msys2 environment and prepends the Go installation to the shell
+`PATH`. You can see the exact steps in `.github/workflows/build.yml`.
 
 ## Certificates
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ The last 2 CGO options were challenging to figure out. The discussion in [curl/c
 
 I started with a few libraries based on what I had seen other people use (`-lcurl -lssl -lcrypto -lz -lws2_32 -lcrypt32 -lbcrypt -lssl -lcrypto -luser32 -lkernel32`) and then added additional libraries based on linker errors and the most likely candidate in `c:\curl\lib`. `-lWldap32` was a little more challenging, but...now you know.
 
+### GitHub Actions
+
+The repository includes an example workflow that builds on Windows using
+[msys2/setup-msys2](https://github.com/msys2/setup-msys2). The workflow installs
+`mingw-w64-x86_64-gcc` and `mingw-w64-x86_64-curl` via `pacman` and then runs the
+build inside the msys2 environment. You can see the exact steps in
+`.github/workflows/build.yml`.
+
 ## Certificates
 
 Depending on your libcurl build/configuration, there may not be any default certificates available. The test application lets you pass in a certificate store (`--certificates`) or will check the (relatively standard) environment variables `CURL_CA_BUNDLE` and `SSL_CERT_FILE`.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ I started with a few libraries based on what I had seen other people use (`-lcur
 The repository includes an example workflow that builds on Windows using
 [msys2/setup-msys2](https://github.com/msys2/setup-msys2). The workflow installs
 `mingw-w64-x86_64-gcc` and `mingw-w64-x86_64-curl` via `pacman`. It then runs the
-build inside the msys2 environment and prepends the Go installation to the shell
-`PATH`. You can see the exact steps in `.github/workflows/build.yml`.
+build inside the msys2 environment. Because Go is installed outside msys2, the
+workflow captures the `GOROOT` from the Windows environment and prepends it to
+the msys2 shell `PATH` before running `go build`. You can see the exact steps in
+`.github/workflows/build.yml`.
 
 ## Certificates
 


### PR DESCRIPTION
## Summary
- add Windows build job using msys2 to handle toolchain setup
- document automated Windows build in README

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_686ebee6da0c8325ac76c0cac55eb0d7